### PR TITLE
Add new section to README.md adressing keyserver failure including solution from issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ echo 'deb http://ppa.launchpad.net/spocon/spocon/ubuntu bionic main' | sudo tee 
 sudo apt-get update
 sudo apt-get -y install spocon
 ```
+
+#### Alternative key import
+
+Some people report problems importing the key for our repository. If the above command fails due to the keyserver, you can try the following beforehand:
+```
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7DBE8BF06EA39B78
+```
+
 ### Requirements
 
 You'll need a [Spotify Premium](https://www.spotify.com/premium/) account in order


### PR DESCRIPTION


I repeatedly had the same problem that was only fixed by appending the protocol "hkp://" and the port ":80" to the front and back of the keyserver's url respectively. There is no proxy, specific firewall, DHCP or anything else involved that I am aware of, so I believe this problem should not just be relevant to myself. Cheers.
See: https://github.com/spocon/spocon/issues/28