### PR TITLE
Update upload.sh librespot and spocon bump to 1.6.3

### DIFF
--- a/Vagrant/upload.sh
+++ b/Vagrant/upload.sh
@@ -3,4 +3,4 @@
 export UPLOAD=true
 GPG_TTY=$(tty)
 export GPG_TTY
-ansible-playbook ../Ansible/start.yml -e librespot_version=1.6.2 -e spocon_version=1.6.2
+ansible-playbook ../Ansible/start.yml -e librespot_version=1.6.3 -e spocon_version=1.6.3


### PR DESCRIPTION
https://github.com/librespot-org/librespot-java/releases/tag/v1.6.3 has been released which fixes some issues regarding APIs and Client Version, this currently breaks the spocon package. See https://github.com/librespot-org/librespot-java/issues/614